### PR TITLE
Fixing command error in azure.yaml 

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -13,7 +13,7 @@ services:
             shell: sh
             continueOnError: false
             interactive: false
-            run: cd ../frontend; pnpm install
+            run: cd ../frontend; npm install
 
 
             


### PR DESCRIPTION
Changing pnmp to npm, this should fix the azd up error reported in [this issue](https://github.com/Azure-Samples/llama-index-python/issues/13) 