### PR TITLE
Update build-test.yml to use ubuntu-latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            os: ["ubuntu-20.04", "windows-latest", macos-latest]
+            os: ["ubuntu-latest", "windows-latest", macos-latest]
             python_version: ["3.11"]
         steps:
           - uses: actions/checkout@v4


### PR DESCRIPTION
The current ubuntu version is deprecated, so the workflow won't run.